### PR TITLE
New Keywords

### DIFF
--- a/catch_phishing.py
+++ b/catch_phishing.py
@@ -34,7 +34,10 @@ suspicious_keywords = [
     'transaction',
     'recover',
     'live',
-    'office'
+    'office',
+    'webscr',
+    'password',
+    'locked'
     ]
 
 highly_suspicious = [
@@ -48,6 +51,7 @@ highly_suspicious = [
     'protonmail',
     'amazon',
     'facebook',
+    'linkedin',
     'microsoft',
     'windows',
     'cgi-bin',
@@ -59,6 +63,11 @@ highly_suspicious = [
     'bitstamp',
     'bittrex',
     'blockchain',
+    'coinbase',
+    'gdax',
+    'poloniex',
+    'bitwage',
+    'bitfinex',
     '.com-',
     '-com.',
     '.net-',


### PR DESCRIPTION
# New Suspicious Keywords

* `webscr` - webscr is fairly specific to PayPal, but it's not an entirely uncommon substr, so I think it probably belongs in the normal suspicious keywords, rather than highly suspicious. 
* `password` - Password resets are a common phishing ruse. 
* `locked` - Locked accounts are also common

# New Highly Suspicious Keywords

* `linkedin` - Another common phishing target. 
* `coinbase` - Very large Bitcoin service. 
* `gdax` - An exchange operated by coinbase.
* `poloniex` - Another large Bitcoin exchange.
* `bitwage` - Another large Bitcoin exchange.
* `bitfinex` - Another large Bitcoin exchange. 

It may be worth just working off #11, and making another PR on my side. 