### PR TITLE
Add check for deeply nested subdomains

### DIFF
--- a/catch_phishing.py
+++ b/catch_phishing.py
@@ -136,6 +136,10 @@ def score_domain(domain):
     # Lots of '-' (ie. www.paypal-datacenter.com-acccount-alert.com)
     if 'xn--' not in domain and domain.count('-') >= 4:
         score += 20
+
+    # Deeply nested subdomains (ie. www.paypal.com.security.accountupdate.gq)
+    if domain.count('.') >= 4:
+        score += 20
     return score
 
 


### PR DESCRIPTION
It's not uncommon to see deeply-nested subdomains instead of dashes in phishing domains. E.g. `www.paypal.com.security.account-update.com`, or `contact-os.apple.acc-support.acc-app456-accessmaill.com`

4 dots is probably the minimum safe amount, since any lower, and you'll start flagging domains like `www.somesite.co.uk` as suspicious. 