### PR TITLE
Upgraded to new version of certstream

### DIFF
--- a/catch_phishing.py
+++ b/catch_phishing.py
@@ -21,6 +21,8 @@ from suspicious import keywords, tlds
 
 from confusables import unconfuse
 
+certstream_url = 'wss://certstream.calidog.io'
+
 log_suspicious = 'suspicious_domains.log'
 
 pbar = tqdm.tqdm(desc='certificate_update', unit='cert')
@@ -129,4 +131,4 @@ def callback(message, context):
 
 
 if __name__ == '__main__':
-    certstream.listen_for_events(callback)
+    certstream.listen_for_events(callback, url=certstream_url)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 termcolor==1.1.0
-certstream==1.8
+certstream==1.10
 entropy==0.10
 tqdm==4.19.4
 tld==0.7.9


### PR DESCRIPTION
and fixed catch_phishing.py to support the change to the API as seen in https://github.com/CaliDog/certstream-python/commit/abd9e79d187841cf92dc5ff241ea5a0f3ab9e6e7