### PR TITLE
Made dots/dashes configurable

### DIFF
--- a/external.yaml
+++ b/external.yaml
@@ -2,6 +2,9 @@
 # and only use your own config in this file.
 override_suspicious.yaml: false
 
+# If true, larger numbers of dots (or dashes) will increase score.
+dots_are_suspect: true
+dashes_are_suspect: true
 keywords:
 # Add your own keywords here or override the score
 # for the ones found in suspicious.yaml, e.g.:


### PR DESCRIPTION
Added support for configuring dots/dashes changing score.
Ideally all factors impacting score should be configurable (untrusted CAs, ignored keywords like email, etc) or at least visible, but this met my needs.