### PR TITLE
Log file is date-based, set script path for YAML files

### DIFF
--- a/catch_phishing.py
+++ b/catch_phishing.py
@@ -15,6 +15,8 @@ import certstream
 import entropy
 import tqdm
 import yaml
+import time
+import os
 from Levenshtein import distance
 from termcolor import colored, cprint
 from tld import get_tld

--- a/catch_phishing.py
+++ b/catch_phishing.py
@@ -23,7 +23,11 @@ from confusables import unconfuse
 
 certstream_url = 'wss://certstream.calidog.io'
 
-log_suspicious = 'suspicious_domains.log'
+log_suspicious = os.path.dirname(os.path.realpath(__file__))+'/suspicious_domains_'+time.strftime("%Y-%m-%d")+'.log'
+
+suspicious_yaml = os.path.dirname(os.path.realpath(__file__))+'/suspicious.yaml'
+
+external_yaml = os.path.dirname(os.path.realpath(__file__))+'/external.yaml'
 
 pbar = tqdm.tqdm(desc='certificate_update', unit='cert')
 
@@ -131,10 +135,10 @@ def callback(message, context):
 
 
 if __name__ == '__main__':
-    with open('suspicious.yaml', 'r') as f:
+    with open(suspicious_yaml, 'r') as f:
         suspicious = yaml.safe_load(f)
 
-    with open('external.yaml', 'r') as f:
+    with open(external_yaml, 'r') as f:
         external = yaml.safe_load(f)
 
     if external['override_suspicious.yaml'] is True:


### PR DESCRIPTION
- Log file is now saved as `suspicious_domains_2019-08-05.log`
- `suspicious.yaml` is now a variable `suspicious_yaml` with full script path
- `external.yaml` is now a variable `external_yaml` with full script path
- Script can be run like `nohup python /root/phishing_catcher/catch_phishing.py > /dev/null 2>&1 &`