### PR TITLE
add docker container for phishing catcher

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.7
+COPY . /app
+WORKDIR /app
+RUN pip install -r requirements.txt
+CMD ["python3.7", "phishing_catcher.py"]

--- a/README.md
+++ b/README.md
@@ -49,6 +49,15 @@ $ ./catch_phishing.py
 
 ![Paypal Phishing](https://i.imgur.com/AK60EYz.png)
 
+### Phishing catcher in Docker container
+
+If you running MacOs or having a different OS version that would make the installation of phishing_catcher difficult, then having the tool dockerized is one of your options.
+
+```
+docker build . -t phishing_catcher
+```
+![container](https://i.imgur.com/nEo13PH.jpg)
+
 # License
 
 GNU GPLv3


### PR DESCRIPTION
I had some issues installing phishing_catcher on different OS, hence dockerizing it was an easier option for a quick setup and run. 

