### PR TITLE
Adapt to changes in the certstream message format

### DIFF
--- a/catch_phishing.py
+++ b/catch_phishing.py
@@ -114,7 +114,7 @@ def callback(message, context):
             score = score_domain(domain.lower())
 
             # If issued from a free CA = more suspicious
-            if "Let's Encrypt" in message['data']['chain'][0]['subject']['aggregated']:
+            if "Let's Encrypt" == message['data']['leaf_cert']['issuer']['O']:
                 score += 10
 
             if score >= 100:


### PR DESCRIPTION
The 'chain' field is no longer provided.

Fortunately it's only used to check if the certificate was issued by Let's Encrypt, and there is a way to keep checking that.