### PR TITLE
Addign new feature to specify minimal required score for CLI print

### DIFF
--- a/external.yaml
+++ b/external.yaml
@@ -2,6 +2,11 @@
 # and only use your own config in this file.
 override_suspicious.yaml: false
 
+# Specify minimal score rating to display the CT Log
+# in CLI output. Use integer value.
+minscore:
+
+
 keywords:
 # Add your own keywords here or override the score
 # for the ones found in suspicious.yaml, e.g.:


### PR DESCRIPTION
This PR introduced one new feature, which is allowing the user to specify the minimal score a CT should reach before printing it out into CLI window. Should help with displaying only really high fidelity results or whatever the user is interested in.

Additionally, I did some code quality changes which I believe make more sense now. For instance, I removed the option for 'updating' suspicious YAML with external YAML, if the user DID NOT SPECIFY that they want to override the original yaml.

My understanding is that if user specifies to override the original yaml, it should actually override it and not update it. We can add a separate feature to update the existing YAML with new keywords or tlds. 